### PR TITLE
Disabled caching on tab.account state

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -84,6 +84,7 @@ angular.module('starter',
 
             .state('tab.account', {
                 url: '/account',
+                cache: false,
                 views: {
                     'tab-account': {
                         templateUrl: 'templates/tab-account.html',


### PR DESCRIPTION
Related to issue: https://github.com/aaronksaunders/parse-starter-ionic/issues/5
