### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Book session on Codementor](https://cdn.codementor.io/badges/book_session_github.svg)](https://www.codementor.io/aaronksaunders)
 
-#Starter Ionic Application Template with Parse Integration
+# Starter Ionic Application Template with Parse Integration
 ---
 ## Update April 15th 2016
 Parse is going away so there is a new project repo here using Firebase, specifically AngularFire with Ionic2. Checkout the starter project and share your thoughts. [https://github.com/aaronksaunders/ionic2-angularfire-sample](https://github.com/aaronksaunders/ionic2-angularfire-sample)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
